### PR TITLE
Improve quoted boolean rule

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/QuotedBooleanCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/QuotedBooleanCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Sonar Puppet Plugin
  * The MIT License (MIT)
  *
@@ -24,7 +24,9 @@
  */
 package com.iadams.sonarqube.puppet.checks;
 
-import com.sonar.sslr.api.*;
+import com.sonar.sslr.api.AstNode;
+import com.sonar.sslr.api.GenericTokenType;
+import com.sonar.sslr.api.Grammar;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
@@ -33,21 +35,16 @@ import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 import org.sonar.squidbridge.checks.SquidCheck;
 
-/**
- * @author iwarapter
- */
 @Rule(
-		key = QuotedBooleanCheck.CHECK_KEY,
+		key = "QuotedBoolean",
 		priority = Priority.MAJOR,
-		name = "Avoid Quoted booleans.",
+		name = "Booleans should not be quoted",
 		tags = Tags.CONFUSING
 )
 @ActivatedByDefault
-@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.READABILITY)
+@SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.FAULT_TOLERANCE)
 @SqaleConstantRemediation("10min")
 public class QuotedBooleanCheck extends SquidCheck<Grammar> {
-
-	public static final String CHECK_KEY = "QuotedBoolean";
 
 	@Override
 	public void init() {
@@ -56,15 +53,15 @@ public class QuotedBooleanCheck extends SquidCheck<Grammar> {
 
 	@Override
 	public void visitNode(AstNode node) {
-		String literal = node.getToken().getValue();
+		String literal = node.getTokenValue();
 		switch (literal) {
 			case "'false'":
 			case "'true'":
 			case "\"false\"":
 			case "\"true\"":
-				getContext().createLineViolation(this, "Do not use quoted booleans.",node);
+				getContext().createLineViolation(this, "Remove quotes.", node);
 				break;
-			default :
+			default:
 				break;
 		}
 	}

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/QuotedBoolean.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/QuotedBoolean.html
@@ -1,5 +1,5 @@
 <p>
-Boolean values (true and false) behave differently when quoted ('true' and 'false'), which can lead to a fair bit of confusion. As a general rule, you should never quote booleans. This is not a style issue, rather a common mistake.
+Boolean values (<code>true</code> and <code>false</code>) behave differently when quoted (<code>'true'</code> and <code>'false'</code>), which can lead to a fair bit of confusion. As a general rule, you should never quote booleans. This is not a style issue, rather a common mistake.
 </p>
 
 <h2>Noncompliant Code Example</h2>

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/QuotedBooleanCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/QuotedBooleanCheckSpec.groovy
@@ -29,10 +29,9 @@ import org.sonar.squidbridge.api.SourceFile
 import org.sonar.squidbridge.checks.CheckMessagesVerifier
 import spock.lang.Specification
 
-/**
- * @author iwarapter
- */
 class QuotedBooleanCheckSpec extends Specification {
+
+	private static final String MESSAGE = "Remove quotes.";
 
 	def "validate rule"() {
 		given:
@@ -42,8 +41,10 @@ class QuotedBooleanCheckSpec extends Specification {
 
 		expect:
 		CheckMessagesVerifier.verify(file.getCheckMessages())
-				.next().atLine(2).withMessage("Do not use quoted booleans.")
-				.next().atLine(6).withMessage("Do not use quoted booleans.")
+				.next().atLine(2).withMessage(MESSAGE)
+				.next().atLine(6).withMessage(MESSAGE)
+				.next().atLine(10).withMessage(MESSAGE)
+				.next().atLine(14).withMessage(MESSAGE)
 				.noMore();
 	}
 }

--- a/puppet-checks/src/test/resources/checks/QuotedBoolean.pp
+++ b/puppet-checks/src/test/resources/checks/QuotedBoolean.pp
@@ -5,3 +5,15 @@ file { '/tmp/foo':
 file { '/tmp/bar':
   purge => 'false',
 }
+
+file { '/tmp/foo':
+  purge => "true",
+}
+
+file { '/tmp/bar':
+  purge => "false",
+}
+
+file { '/tmp/bar':
+  purge => "falsez",
+}

--- a/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
+++ b/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
@@ -244,9 +244,12 @@ file { '/tmp/foo':
       <pre>
 file { '/tmp/foo':
   purge => true,
-}</pre>]]>
+}</pre>
+<p>This rule is deprecated, use <a href="coding_rules#rule_key=puppet:QuotedBoolean">QuotedBoolean</a> instead.</p>
+     ]]>
     </description>
     <priority>CRITICAL</priority>
+    <status>DEPRECATED</status>
   </rule>
   <rule>
     <key>puppet_url_without_modules</key>


### PR DESCRIPTION
- Rule name should comply to the following convention: "... should..." or "... should not..."
- Rule message should tell the user what to do: "Do not use quotes" => "Remove quotes"
- `<code>` tag can be used to highlight code in the HTML description
- Fixing SQALE characteristic
- Deprecating releated Puppet Lint rule
- Adding more tests
