### PR TITLE
Improve FileModes check

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/CheckUtils.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/CheckUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Sonar Puppet Plugin
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Iain Adams
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.iadams.sonarqube.puppet.checks;
+
+import java.util.regex.Pattern;
+
+public class CheckUtils {
+
+  private static final String REGEX_VARIABLE_USAGE = ".*\\$\\{.*";
+  private static final Pattern PATTERN_VARIABLE_USAGE = Pattern.compile(REGEX_VARIABLE_USAGE);
+
+  public static boolean doesStringContainsVariables(String string) {
+    return PATTERN_VARIABLE_USAGE.matcher(string).matches();
+  }
+
+}

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
@@ -42,7 +42,7 @@ import static com.iadams.sonarqube.puppet.api.PuppetTokenType.*;
 
 @Rule(
   key = "FileModes",
-  name = "File modes should be represented as 4 digits rather than 3 or symbolically.",
+  name = "File mode should be represented by a valid 4-digit octal value (rather than 3) or symbolically",
   priority = Priority.MINOR,
   tags = {Tags.CONVENTION})
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.FAULT_TOLERANCE)

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
@@ -44,7 +44,7 @@ import static com.iadams.sonarqube.puppet.api.PuppetTokenType.*;
   key = "FileModes",
   name = "File mode should be represented by a valid 4-digit octal value (rather than 3) or symbolically",
   priority = Priority.MINOR,
-  tags = {Tags.CONVENTION})
+  tags = {Tags.BUG})
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.FAULT_TOLERANCE)
 @SqaleConstantRemediation("10min")
 @ActivatedByDefault

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
@@ -38,8 +38,7 @@ import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 import org.sonar.squidbridge.checks.SquidCheck;
 
-import static com.iadams.sonarqube.puppet.api.PuppetTokenType.DOUBLE_QUOTED_STRING_LITERAL;
-import static com.iadams.sonarqube.puppet.api.PuppetTokenType.SINGLE_QUOTED_STRING_LITERAL;
+import static com.iadams.sonarqube.puppet.api.PuppetTokenType.*;
 
 @Rule(
   key = "FileModes",
@@ -81,7 +80,9 @@ public class FileModeCheck extends SquidCheck<Grammar> {
   }
 
   private void checkMode(AstNode node) {
-    if (node.getToken().getType().equals(SINGLE_QUOTED_STRING_LITERAL) || node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL)) {
+    if (node.getToken().getType().equals(OCTAL_INTEGER) || node.getToken().getType().equals(INTEGER)) {
+      getContext().createLineViolation(this, "Set the file mode to a 4-digit octal value surrounded by single quotes.", node.getTokenLine());
+    } else if (node.getToken().getType().equals(SINGLE_QUOTED_STRING_LITERAL) || node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL)) {
       if (!pattern.matcher(node.getTokenValue()).matches()) {
         getContext().createLineViolation(this, "File modes should be represented as 4 digits rather than 3, to explicitly show that they are octal values.", node.getTokenLine());
       }

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/FileModeCheck.java
@@ -88,9 +88,11 @@ public class FileModeCheck extends SquidCheck<Grammar> {
     } else if (node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL) && PATTERN.matcher(node.getTokenValue()).matches()) {
       getContext().createLineViolation(this, MESSAGE_DOUBLE_QUOTES, node.getTokenLine());
     } else if (node.getToken().getType().equals(SINGLE_QUOTED_STRING_LITERAL) && !PATTERN.matcher(node.getTokenValue()).matches()
-      || node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL) && !PATTERN.matcher(node.getTokenValue()).matches()) {
+      || node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL) && !PATTERN.matcher(node.getTokenValue()).matches()
+      && !CheckUtils.doesStringContainsVariables(node.getTokenValue())) {
       getContext().createLineViolation(this, MESSAGE_INVALID, node.getTokenLine());
     }
+
   }
 
 }

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
@@ -50,6 +50,8 @@ file { '/var/log/syslog':
 </pre>
 
 <h2>See</h2>
+See Puppet Labs Puppet Language Style Guide:
 <ul>
-  <li><a href="http://docs.puppetlabs.com/guides/style_guide.html#file-modes">See Puppet Labs Puppet Language Style Guide</a></li>
+  <li><a href="http://docs.puppetlabs.com/guides/style_guide.html#file-modes">File Modes</a></li>
+  <li><a href="https://docs.puppetlabs.com/guides/style_guide.html#quoting">Quoting</a></li>
 </ul>

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
@@ -1,5 +1,9 @@
-<p>
-  File modes should be represented as 4 digits rather than 3, to explicitly show that they are octal values. File modes can also be represented symbolically e.g. u=rw,g=r.
+<p>File modes should be represented either as valid:
+<ul>
+  <li>POSIX numeric notation on 4 digits to explicitly show that they are octal values</li>
+  <li>Or symbolically, e.g. <code>u=rw,g=r</code></li>
+</ul>
+Both representations must be surrounded by single quotes.
 </p>
 
 <h2>Noncompliant Code Example</h2>
@@ -7,7 +11,27 @@
 <pre>
 file { '/var/log/syslog':
   ensure => present,
-  mode   => 644,
+  mode   => 644,      # Should be set to '0644' instead
+}
+
+file { '/var/log/syslog':
+  ensure => present,
+  mode   => '644',    # Should be set to '0644' instead
+}
+
+file { '/var/log/syslog':
+  ensure => present,
+  mode   => "644",    # Double quotes should be replaced by single quotes
+}
+
+file { '/var/log/syslog':
+  ensure => present,
+  mode   => '0999',   # Invalid file mode value, should be updated to a valid value
+}
+
+file { '/var/log/syslog':
+  ensure => present,
+  mode   => 'blabla', # Invalid file mode value, should be updated to a valid value
 }
 </pre>
 
@@ -15,10 +39,16 @@ file { '/var/log/syslog':
 
 <pre>
 file { '/var/log/syslog':
-  ensure => file,
+  ensure => present,
   mode   => 'o-rwx',
 }
+
+file { '/var/log/syslog':
+  ensure => present,
+  mode   => '0644',
+}
 </pre>
+
 <h2>See</h2>
 <ul>
   <li><a href="http://docs.puppetlabs.com/guides/style_guide.html#file-modes">See Puppet Labs Puppet Language Style Guide</a></li>

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/FileModes.html
@@ -21,7 +21,7 @@ file { '/var/log/syslog':
 
 file { '/var/log/syslog':
   ensure => present,
-  mode   => "644",    # Double quotes should be replaced by single quotes
+  mode   => "0644",   # Double quotes should be replaced by single quotes
 }
 
 file { '/var/log/syslog':

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
@@ -31,8 +31,9 @@ import spock.lang.Specification
 
 class FileModeCheckSpec extends Specification {
 
-    private static final String MESSAGE = "File modes should be represented as 4 digits rather than 3, to explicitly show that they are octal values.";
-    private static final String MESSAGE_INTEGER = "Set the file mode to a 4-digit octal value surrounded by single quotes.";
+    private static final String MESSAGE_OCTAL = "Set the file mode to a 4-digit octal value surrounded by single quotes.";
+    private static final String MESSAGE_DOUBLE_QUOTES = "Replace double quotes by single quotes.";
+    private static final String MESSAGE_INVALID = "Update the file mode to a valid value surrounded by single quotes.";
 
     def "validate check"() {
         given:
@@ -41,14 +42,18 @@ class FileModeCheckSpec extends Specification {
 
         expect:
         CheckMessagesVerifier.verify(file.getCheckMessages())
-                .next().atLine(2).withMessage(MESSAGE)
-                .next().atLine(22).withMessage(MESSAGE)
-                .next().atLine(32).withMessage(MESSAGE)
-                .next().atLine(44).withMessage(MESSAGE)
-                .next().atLine(52).withMessage(MESSAGE_INTEGER)
-                .next().atLine(56).withMessage(MESSAGE_INTEGER)
-                .next().atLine(60).withMessage(MESSAGE_INTEGER)
-                .next().atLine(64).withMessage(MESSAGE_INTEGER)
+                .next().atLine(2).withMessage(MESSAGE_INVALID)
+                .next().atLine(22).withMessage(MESSAGE_INVALID)
+                .next().atLine(32).withMessage(MESSAGE_INVALID)
+                .next().atLine(44).withMessage(MESSAGE_INVALID)
+                .next().atLine(52).withMessage(MESSAGE_OCTAL)
+                .next().atLine(56).withMessage(MESSAGE_OCTAL)
+                .next().atLine(60).withMessage(MESSAGE_OCTAL)
+                .next().atLine(64).withMessage(MESSAGE_OCTAL)
+                .next().atLine(68).withMessage(MESSAGE_DOUBLE_QUOTES)
+                .next().atLine(72).withMessage(MESSAGE_INVALID)
+                .next().atLine(76).withMessage(MESSAGE_DOUBLE_QUOTES)
+                .next().atLine(80).withMessage(MESSAGE_INVALID)
                 .noMore();
     }
 }

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
@@ -43,6 +43,7 @@ class FileModeCheckSpec extends Specification {
                 .next().atLine(2).withMessage(MESSAGE)
                 .next().atLine(22).withMessage(MESSAGE)
                 .next().atLine(32).withMessage(MESSAGE)
+                .next().atLine(44).withMessage(MESSAGE)
                 .noMore();
     }
 }

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/FileModeCheckSpec.groovy
@@ -32,6 +32,7 @@ import spock.lang.Specification
 class FileModeCheckSpec extends Specification {
 
     private static final String MESSAGE = "File modes should be represented as 4 digits rather than 3, to explicitly show that they are octal values.";
+    private static final String MESSAGE_INTEGER = "Set the file mode to a 4-digit octal value surrounded by single quotes.";
 
     def "validate check"() {
         given:
@@ -44,6 +45,10 @@ class FileModeCheckSpec extends Specification {
                 .next().atLine(22).withMessage(MESSAGE)
                 .next().atLine(32).withMessage(MESSAGE)
                 .next().atLine(44).withMessage(MESSAGE)
+                .next().atLine(52).withMessage(MESSAGE_INTEGER)
+                .next().atLine(56).withMessage(MESSAGE_INTEGER)
+                .next().atLine(60).withMessage(MESSAGE_INTEGER)
+                .next().atLine(64).withMessage(MESSAGE_INTEGER)
                 .noMore();
     }
 }

--- a/puppet-checks/src/test/resources/checks/file_mode.pp
+++ b/puppet-checks/src/test/resources/checks/file_mode.pp
@@ -47,3 +47,19 @@ File {
 File {
 	mode => '0755',
 }
+
+file { 'foo':
+	mode => 755,
+}
+
+file { 'foo':
+	mode => 0755,
+}
+
+File {
+	mode => 755,
+}
+
+File {
+	mode => 0755,
+}

--- a/puppet-checks/src/test/resources/checks/file_mode.pp
+++ b/puppet-checks/src/test/resources/checks/file_mode.pp
@@ -39,3 +39,11 @@ file {
 		ensure => directory,
 		mode   => '0755';
 }
+
+File {
+  mode => '755',
+}
+
+File {
+	mode => '0755',
+}

--- a/puppet-checks/src/test/resources/checks/file_mode.pp
+++ b/puppet-checks/src/test/resources/checks/file_mode.pp
@@ -1,5 +1,5 @@
 file { 'foo':
-  mode => '777'
+  mode => '777'  # Noncompliant
 }
 
 file { 'foo':
@@ -19,7 +19,7 @@ file { 'foo':
 }
 
 file { 'foo':
-  mode => 'undef'
+  mode => 'undef'  # Noncompliant
 }
 
 file { '/etc/passwd':
@@ -29,7 +29,7 @@ file { '/etc/passwd':
 file {
 	'/etc/rc.d':
 		ensure => directory,
-		mode   => '755';
+		mode   => '755';  # Noncompliant
 
 	'/etc/rc.d/init.d':
 		ensure => directory,
@@ -41,7 +41,7 @@ file {
 }
 
 File {
-  mode => '755',
+  mode => '755',  # Noncompliant
 }
 
 File {
@@ -49,35 +49,35 @@ File {
 }
 
 file { 'foo':
-	mode => 755,
+	mode => 755,  # Noncompliant
 }
 
 file { 'foo':
-	mode => 0755,
+	mode => 0755,  # Noncompliant
 }
 
 File {
-	mode => 755,
+	mode => 755,  # Noncompliant
 }
 
 File {
-	mode => 0755,
+	mode => 0755,  # Noncompliant
 }
 
 file { 'foo':
-	mode => "0755",
+	mode => "0755",  # Noncompliant
 }
 
 file { 'foo':
-	mode => "abc",
+	mode => "abc",  # Noncompliant
 }
 
 File {
-	mode => "0755",
+	mode => "0755",  # Noncompliant
 }
 
 File {
-	mode => "abc",
+	mode => "abc",  # Noncompliant
 }
 
 file { 'foo':

--- a/puppet-checks/src/test/resources/checks/file_mode.pp
+++ b/puppet-checks/src/test/resources/checks/file_mode.pp
@@ -63,3 +63,19 @@ File {
 File {
 	mode => 0755,
 }
+
+file { 'foo':
+	mode => "0755",
+}
+
+file { 'foo':
+	mode => "abc",
+}
+
+File {
+	mode => "0755",
+}
+
+File {
+	mode => "abc",
+}

--- a/puppet-checks/src/test/resources/checks/file_mode.pp
+++ b/puppet-checks/src/test/resources/checks/file_mode.pp
@@ -79,3 +79,11 @@ File {
 File {
 	mode => "abc",
 }
+
+file { 'foo':
+	mode => "u=${var}",
+}
+
+File {
+	mode => "u=${var}",
+}

--- a/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
+++ b/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
@@ -373,7 +373,8 @@ file { '/tmp/foo':
       <pre>
 file { '/tmp/foo':
   mode => '0666',
-}</pre>]]>
+}</pre>
+<p>This rule is deprecated, use <a href="coding_rules#rule_key=puppet:FileModes">FileModes</a> instead.</p>]]>
     </description>
     <status>DEPRECATED</status>
     <priority>MINOR</priority>
@@ -397,9 +398,11 @@ file { '/tmp/foo':
       <pre>
 file { '/tmp/foo':
   mode => '0666',
-}</pre>]]>
+}</pre>
+<p>This rule is deprecated, use <a href="coding_rules#rule_key=puppet:FileModes">FileModes</a> instead.</p>]]>
     </description>
     <priority>MINOR</priority>
+    <status>DEPRECATED</status>
   </rule>
   <rule>
     <key>duplicate_params</key>


### PR DESCRIPTION
- Fix false negatives on Resource Default Statements
- Fix false negatives on mode set to integer or octal values
- Double-quoted strings should not be allowed
- Deprecate unquoted_file_mode rule and add links to the replacement rule
- Extend FilesMode rule description
- Fix false positives on string containing variables
- Tag FilesModes as BUG
- Add reference to the Puppet Las Puppet Language Style Guide, Quoting section
- Add Noncompliant comments to file_mode.pp to quickly find out where issues are expected to be raised
