### PR TITLE
Improve LineLength rule

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
@@ -54,13 +54,13 @@ import org.sonar.squidbridge.checks.SquidCheck;
 @SqaleConstantRemediation("1min")
 public class LineLengthCheck extends SquidCheck<Grammar> implements CharsetAwareVisitor {
 
-  private static final int DEFAULT_MAXIMUM_LINE_LENHGTH = 80;
+  private static final int DEFAULT_MAXIMUM_LINE_LENGTH = 80;
   private Charset charset;
 
   @RuleProperty(
     key = "maximumLineLength",
-    defaultValue = "" + DEFAULT_MAXIMUM_LINE_LENHGTH)
-  public int maximumLineLength = DEFAULT_MAXIMUM_LINE_LENHGTH;
+    defaultValue = "" + DEFAULT_MAXIMUM_LINE_LENGTH)
+  public int maximumLineLength = DEFAULT_MAXIMUM_LINE_LENGTH;
 
   @Override
   public void setCharset(Charset charset) {

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Sonar Puppet Plugin
  * The MIT License (MIT)
  *
@@ -28,6 +28,12 @@ import com.google.common.io.Files;
 import com.iadams.sonarqube.puppet.CharsetAwareVisitor;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import javax.annotation.Nullable;
+
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.utils.SonarException;
 import org.sonar.check.Priority;
@@ -38,53 +44,47 @@ import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 import org.sonar.squidbridge.checks.SquidCheck;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.List;
-
 @Rule(
-		key = "LineLength",
-		priority = Priority.MINOR,
-		name = "Lines should not be too long",
-		tags = Tags.CONVENTION
-)
+  key = "LineLength",
+  priority = Priority.MINOR,
+  name = "Lines should not be too long",
+  tags = Tags.CONVENTION)
 @ActivatedByDefault
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.READABILITY)
 @SqaleConstantRemediation("1min")
 public class LineLengthCheck extends SquidCheck<Grammar> implements CharsetAwareVisitor {
 
-	private static final int DEFAULT_MAXIMUM_LINE_LENHGTH = 80;
-	private Charset charset;
+  private static final int DEFAULT_MAXIMUM_LINE_LENHGTH = 80;
+  private Charset charset;
 
-	@RuleProperty(
-			key = "maximumLineLength",
-			defaultValue = "" + DEFAULT_MAXIMUM_LINE_LENHGTH)
-	public int maximumLineLength = DEFAULT_MAXIMUM_LINE_LENHGTH;
+  @RuleProperty(
+    key = "maximumLineLength",
+    defaultValue = "" + DEFAULT_MAXIMUM_LINE_LENHGTH)
+  public int maximumLineLength = DEFAULT_MAXIMUM_LINE_LENHGTH;
 
-	@Override
-	public void setCharset(Charset charset) {
-		this.charset = charset;
-	}
+  @Override
+  public void setCharset(Charset charset) {
+    this.charset = charset;
+  }
 
-	@Override
-	public void visitFile(@Nullable AstNode astNode) {
-		List<String> lines;
-		try {
-			lines = Files.readLines(getContext().getFile(), charset);
-		} catch (IOException e) {
-			throw new SonarException(e);
-		}
-		for (int i = 0; i < lines.size(); i++) {
-			String line = lines.get(i);
-			if (line.length() > maximumLineLength) {
-				getContext().createLineViolation(this,
-						"The line contains {0,number,integer} characters which is greater than {1,number,integer} authorized.",
-						i + 1,
-						line.length(),
-						maximumLineLength);
-			}
-		}
-	}
+  @Override
+  public void visitFile(@Nullable AstNode astNode) {
+    List<String> lines;
+    try {
+      lines = Files.readLines(getContext().getFile(), charset);
+    } catch (IOException e) {
+      throw new SonarException(e);
+    }
+    for (int i = 0; i < lines.size(); i++) {
+      String line = lines.get(i);
+      if (line.length() > maximumLineLength) {
+        getContext().createLineViolation(this,
+          "The line contains {0,number,integer} characters which is greater than {1,number,integer} authorized.",
+          i + 1,
+          line.length(),
+          maximumLineLength);
+      }
+    }
+  }
 
 }

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/LineLengthCheck.java
@@ -54,7 +54,7 @@ import org.sonar.squidbridge.checks.SquidCheck;
 @SqaleConstantRemediation("1min")
 public class LineLengthCheck extends SquidCheck<Grammar> implements CharsetAwareVisitor {
 
-  private static final int DEFAULT_MAXIMUM_LINE_LENGTH = 80;
+  private static final int DEFAULT_MAXIMUM_LINE_LENGTH = 140;
   private Charset charset;
 
   @RuleProperty(

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/LineLength.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/LineLength.html
@@ -1,1 +1,5 @@
 <p>Having to scroll horizontally makes it harder to get a quick overview and understanding of any piece of code.</p>
+<h2>See</h2>
+<ul>
+    <li><a href="https://docs.puppetlabs.com/guides/style_guide.html#spacing-indentation-and-whitespace">See Puppet Labs Puppet Language Style Guide</a></li>
+</ul>


### PR DESCRIPTION
- Indent the SonarQube way
- Fix typo in constant name
- Set default value to 140 instead of 80 (too small and not compliant to https://docs.puppetlabs.com/guides/style_guide.html#spacing-indentation-and-whitespace
- Add a link to the Puppet Labs Puppet Language Style Guide
