### PR TITLE
Deprecate rule unquoted_node_name as this syntax is not valid per the…

### DIFF
--- a/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
+++ b/sonar-puppet-plugin/src/main/resources/com/iadams/sonarqube/puppet/pplint/rules.xml
@@ -790,9 +790,11 @@ node server1 {
 
       <pre>
 node 'server1' {
-}</pre>]]>
+}</pre>
+<p>This rule is deprecated. As this syntax is not valid according to the language specifications, a parsing error is raised in such a case.</p>]]>
     </description>
     <priority>MAJOR</priority>
+    <status>DEPRECATED</status>
   </rule>
   <rule>
     <key>IgnoredPuppetLintRule</key>


### PR DESCRIPTION
… language specifications. A parsing error is raised in such a case.
