### PR TITLE
Fix false negatives on PuppetURLModules

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheck.java
@@ -37,7 +37,7 @@ import org.sonar.sslr.parser.LexerlessGrammar;
 
 @Rule(
   key = "PuppetURLModules",
-  name = "\"Puppet:///\" URL path should start with \"modules/\"",
+  name = "\"puppet:///\" URL path should start with \"modules/\"",
   priority = Priority.CRITICAL,
   tags = {Tags.PITFALL})
 @SqaleSubCharacteristic(RulesDefinition.SubCharacteristics.INSTRUCTION_RELIABILITY)

--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheck.java
@@ -24,7 +24,7 @@
  */
 package com.iadams.sonarqube.puppet.checks;
 
-import com.iadams.sonarqube.puppet.api.PuppetGrammar;
+import com.iadams.sonarqube.puppet.api.PuppetTokenType;
 import com.sonar.sslr.api.AstNode;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
@@ -34,9 +34,6 @@ import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 import org.sonar.squidbridge.checks.SquidCheck;
 import org.sonar.sslr.parser.LexerlessGrammar;
-
-import static com.iadams.sonarqube.puppet.api.PuppetTokenType.DOUBLE_QUOTED_STRING_LITERAL;
-import static com.iadams.sonarqube.puppet.api.PuppetTokenType.SINGLE_QUOTED_STRING_LITERAL;
 
 @Rule(
   key = "PuppetURLModules",
@@ -50,54 +47,12 @@ public class PuppetURLModulesCheck extends SquidCheck<LexerlessGrammar> {
 
   @Override
   public void init() {
-    subscribeTo(PuppetGrammar.RESOURCE, PuppetGrammar.RESOURCE_OVERRIDE);
+    subscribeTo(PuppetTokenType.DOUBLE_QUOTED_STRING_LITERAL, PuppetTokenType.SINGLE_QUOTED_STRING_LITERAL);
   }
 
   @Override
   public void visitNode(AstNode node) {
-    if (node.is(PuppetGrammar.RESOURCE)) {
-      checkResourceInstance(node);
-      checkResourceDefault(node);
-    } else if (node.is(PuppetGrammar.RESOURCE_OVERRIDE)) {
-      checkResourceOverride(node);
-    }
-  }
-
-  private void checkResourceInstance(AstNode resourceNode) {
-    if ("file".equals(resourceNode.getTokenValue())) {
-      for (AstNode resourceInstNode : resourceNode.getChildren(PuppetGrammar.RESOURCE_INST)) {
-        for (AstNode paramNode : resourceInstNode.getFirstChild(PuppetGrammar.PARAMS).getChildren(PuppetGrammar.PARAM)) {
-          if ("source".equals(paramNode.getTokenValue())) {
-            checkSourcePath(paramNode.getFirstChild(PuppetGrammar.EXPRESSION));
-          }
-        }
-      }
-    }
-  }
-
-  private void checkResourceDefault(AstNode resourceNode) {
-    if ("File".equals(resourceNode.getTokenValue())) {
-      for (AstNode paramNode : resourceNode.getFirstChild(PuppetGrammar.PARAMS).getChildren(PuppetGrammar.PARAM)) {
-        if ("source".equals(paramNode.getTokenValue())) {
-          checkSourcePath(paramNode.getFirstChild(PuppetGrammar.EXPRESSION));
-        }
-      }
-    }
-  }
-
-  private void checkResourceOverride(AstNode resourceOverrideNode) {
-    if ("File".equals(resourceOverrideNode.getTokenValue())) {
-      for (AstNode paramNode : resourceOverrideNode.getFirstChild(PuppetGrammar.ANY_PARAMS).getChildren(PuppetGrammar.PARAM, PuppetGrammar.ADD_PARAM)) {
-        if ("source".equals(paramNode.getTokenValue())) {
-          checkSourcePath(paramNode.getFirstChild(PuppetGrammar.EXPRESSION));
-        }
-      }
-    }
-  }
-
-  private void checkSourcePath(AstNode node) {
-    if ((node.getToken().getType().equals(DOUBLE_QUOTED_STRING_LITERAL) || node.getToken().getType().equals(SINGLE_QUOTED_STRING_LITERAL))
-      && node.getTokenValue().substring(1).startsWith("puppet:///")
+    if (node.getTokenValue().substring(1).startsWith("puppet:///")
       && !node.getTokenValue().substring(1).startsWith("puppet:///modules/")
       && !node.getTokenValue().substring(1).startsWith("puppet:///$")) {
       getContext().createLineViolation(this, "Add \"modules/\" to the path.", node);

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/PuppetURLModules.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/PuppetURLModules.html
@@ -1,4 +1,5 @@
-<p>When using <code>puppet:///</code> URLs, you should ensure that the path starts with <code>modules/</code> (as the most commonly used mount point in the Puppet file server).</p>
+<p>When using <code>puppet:///</code> URLs, you should ensure that the path starts with <code>modules/</code>.
+Indeed, it is the most commonly used mount point in a Puppet file server.</p>
 
 <h2>Noncompliant Code Example</h2>
 <pre>
@@ -13,3 +14,8 @@ file { '/etc/apache/apache2.conf':
   source => 'puppet:///modules/apache2/etc/apache/apache2.conf',
 }
 </pre>
+
+<h2>See</h2>
+<ul>
+  <li><a href="https://docs.puppetlabs.com/guides/file_serving.html#serving-module-files">The Puppet File Server Guide</a></li>
+</ul>

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/PuppetURLModulesCheckSpec.groovy
@@ -49,6 +49,8 @@ class PuppetURLModulesCheckSpec extends Specification {
       .next().atLine(34).withMessage(MESSAGE)
       .next().atLine(38).withMessage(MESSAGE)
       .next().atLine(42).withMessage(MESSAGE)
+      .next().atLine(50).withMessage(MESSAGE)
+      .next().atLine(78).withMessage(MESSAGE)
       .noMore();
   }
 }

--- a/puppet-checks/src/test/resources/checks/puppet_url_modules.pp
+++ b/puppet-checks/src/test/resources/checks/puppet_url_modules.pp
@@ -47,7 +47,7 @@ File['/etc/apache/apache2.conf'] {
 }
 
 file { '/etc/apache/apache2.conf':
-	abc => 'puppet:///apache2/etc/apache/apache2.conf',
+	abc => 'puppet:///apache2/etc/apache/apache2.conf',    # Noncompliant
 }
 
 file { '/etc/apache/apache2.conf':
@@ -73,4 +73,11 @@ File['/etc/apache/apache2.conf'] {
 
 file { '/etc/apache/apache2.conf':
 	source => "puppet:///${var}",
+}
+
+$source = "puppet:///apache2/etc/apache/apache2.conf"  # Noncompliant
+$source = "puppet:///${var}/etc/apache/apache2.conf"
+
+file { '/etc/apache/apache2.conf':
+	source => $source,
 }


### PR DESCRIPTION
No need to check for the source file attribute. Indeed variables can be used.
