### PR TITLE
Remove check for unquoted variable title

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/UnquotedResourceTitleCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/UnquotedResourceTitleCheck.java
@@ -52,7 +52,7 @@ public class UnquotedResourceTitleCheck extends PuppetCheckVisitor {
 
   @Override
   public void visitNode(AstNode node) {
-    if (node.getFirstChild(PuppetTokenType.NAME) != null || node.getFirstChild(PuppetTokenType.VARIABLE) != null) {
+    if (node.getFirstChild(PuppetTokenType.NAME) != null ) {
       addIssue(node, this, "Quote this resource title.");
     } else if (node.getFirstChild(PuppetGrammar.ARRAY) != null) {
       boolean hasUnquotedTitle = false;

--- a/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/UnquotedResourceTitle.html
+++ b/puppet-checks/src/main/resources/org/sonar/l10n/pp/rules/puppet/UnquotedResourceTitle.html
@@ -1,15 +1,9 @@
 <p>
-    All resource titles must be quoted. If you are using an array of titles you must quote each title in the array, but
-    cannot quote the array itself.<br/>
-    Note also that variables standing by themselves should not be quoted, unless they are a resource title.
+    All resource titles must be quoted. If you are using an array of titles you must quote each title in the array, but should not quote the array itself.<br/>
 </p>
 <h2>Noncompliant Code Example</h2>
 <pre>
 file { foo:    # Noncompliant
-  ensure => directory,
-}
-
-file { $foo:   # Noncompliant
   ensure => directory,
 }
 
@@ -23,10 +17,6 @@ file { [
 <h2>Compliant Solution</h2>
 <pre>
 file { 'foo':
-  ensure => directory,
-}
-
-file { "${foo}":
   ensure => directory,
 }
 

--- a/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/UnquotedResourceTitleCheckSpec.groovy
+++ b/puppet-checks/src/test/groovy/com/iadams/sonarqube/puppet/checks/UnquotedResourceTitleCheckSpec.groovy
@@ -43,7 +43,6 @@ class UnquotedResourceTitleCheckSpec extends Specification {
     expect:
     CheckMessagesVerifier.verify(file.getCheckMessages())
       .next().atLine(1).withMessage(MESSAGE)
-      .next().atLine(4).withMessage(MESSAGE)
       .next().atLine(7).withMessage(MESSAGE_ARRAY)
       .noMore();
   }

--- a/puppet-checks/src/test/resources/checks/unquoted_resource_title.pp
+++ b/puppet-checks/src/test/resources/checks/unquoted_resource_title.pp
@@ -1,9 +1,6 @@
 file { foo:    # Noncompliant
 }
 
-file { $foo:   # Noncompliant
-}
-
 file { [
   abc,       # Noncompliant
   $var,      # Noncompliant
@@ -12,9 +9,6 @@ file { [
 }
 
 file { 'foo':
-}
-
-file { "${foo}":
 }
 
 file { [


### PR DESCRIPTION
Titles only require quotes if they're plain strings. This is actually incorrect in the docs right now (says it should be done for variables), there's a ticket to fix it: https://tickets.puppetlabs.com/browse/DOCUMENT-468
