### PR TITLE
Adds exception for variable strings for `defined`

### DIFF
--- a/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/SingleQuotedStringContainingVariablesCheck.java
+++ b/puppet-checks/src/main/java/com/iadams/sonarqube/puppet/checks/SingleQuotedStringContainingVariablesCheck.java
@@ -51,7 +51,7 @@ public class SingleQuotedStringContainingVariablesCheck extends PuppetCheckVisit
 
   @Override
   public void visitNode(AstNode node) {
-    if (CheckStringUtils.containsVariable(node.getTokenValue())) {
+    if (CheckStringUtils.containsVariable(node.getTokenValue()) && !("defined".equals(node.getTokenValue()))) {
       addIssue(node, this, "Use double quotes instead of single quotes for the string to be interpolated.");
     }
   }

--- a/puppet-checks/src/test/resources/checks/single_quoted_string_containing_variables.pp
+++ b/puppet-checks/src/test/resources/checks/single_quoted_string_containing_variables.pp
@@ -8,3 +8,5 @@ class {'apache':
 class {'apache':
   version => 'abc $ def',
 }
+
+defined('$foo') # compliant, defined takes a variable as a string


### PR DESCRIPTION
The `defined` function is the exception to this rule, as it can check if a variable has actually been defined, which requires the variable be given as a string.

See https://docs.puppetlabs.com/references/latest/function.html#defined
