### PR TITLE
WIP: [HELP needed] first attempt based on sonar-puppet module to parse generic-test-data

### DIFF
--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/PuppetReportSensor.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/PuppetReportSensor.java
@@ -1,0 +1,99 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.utils.WildcardPattern;
+
+public abstract class PuppetReportSensor implements Sensor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PuppetReportSensor.class);
+
+  protected Configuration conf;
+
+  public PuppetReportSensor(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void describe(SensorDescriptor descriptor) {
+    descriptor
+      .name(getClass().getSimpleName())
+      .onlyOnLanguage(Puppet.KEY)
+      .onlyOnFileType(InputFile.Type.MAIN);
+  }
+
+  @Override
+  public void execute(SensorContext context) {
+    try {
+      List<File> reports = getReports(conf, context.fileSystem().baseDir().getPath(), reportPathKey(), defaultReportPath());
+      processReports(context, reports);
+    } catch (javax.xml.stream.XMLStreamException e) {
+      String msg = new StringBuilder()
+          .append("Cannot feed the data into sonar, details: '")
+          .append(e)
+          .append("'")
+          .toString();
+      throw new IllegalStateException(msg, e);
+    }
+  }
+
+  public static List<File> getReports(Configuration conf, String baseDirPath, String reportPathPropertyKey, String defaultReportPath) {
+    String reportPath = conf.get(reportPathPropertyKey).orElse(defaultReportPath);
+    boolean propertyIsProvided = !Objects.equals(reportPath, defaultReportPath);
+
+    LOG.debug("Using pattern '{}' to find reports", reportPath);
+
+    DirectoryScanner scanner = new DirectoryScanner(new File(baseDirPath), WildcardPattern.create(reportPath));
+    List<File> includedFiles = scanner.getIncludedFiles();
+
+    if (includedFiles.isEmpty()) {
+      if (propertyIsProvided) {
+        // try absolute path
+        File file = new File(reportPath);
+        if (!file.exists()) {
+          LOG.warn("No report was found for {} using pattern {}", reportPathPropertyKey, reportPath);
+        } else {
+          includedFiles.add(file);
+        }
+      } else {
+        LOG.debug("No report was found for {} using default pattern {}", reportPathPropertyKey, reportPath);
+      }
+    }
+    return includedFiles;
+  }
+
+  protected void processReports(SensorContext context, List<File> reports) throws javax.xml.stream.XMLStreamException {
+  }
+
+  protected abstract String reportPathKey();
+
+  protected abstract String defaultReportPath();
+
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/parser/StaxParser.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/parser/StaxParser.java
@@ -1,0 +1,95 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.parser;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLResolver;
+import javax.xml.stream.XMLStreamException;
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.staxmate.SMInputFactory;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+
+/**
+ * Class copied from deprecated class StaxParser of sonar-plugin-api.
+ */
+public class StaxParser {
+
+  private SMInputFactory inf;
+
+  private XmlStreamHandler streamHandler;
+
+  public StaxParser(XmlStreamHandler streamHandler) {
+    this.streamHandler = streamHandler;
+    WstxInputFactory xmlFactory = (WstxInputFactory) XMLInputFactory.newInstance();
+    xmlFactory.configureForLowMemUsage();
+    xmlFactory.getConfig().setUndeclaredEntityResolver(new UndeclaredEntitiesXMLResolver());
+    xmlFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
+    xmlFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    xmlFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+    inf = new SMInputFactory(xmlFactory);
+  }
+
+  public void parse(File xmlFile) throws XMLStreamException {
+    try (FileInputStream input = new FileInputStream(xmlFile)) {
+      parse(input);
+    } catch (IOException e) {
+      throw new XMLStreamException(e);
+    }
+  }
+
+  public void parse(InputStream xmlInput) throws XMLStreamException {
+    SMHierarchicCursor rootCursor = inf.rootElementCursor(xmlInput);
+    try {
+      streamHandler.stream(rootCursor);
+    } finally {
+      rootCursor.getStreamReader().closeCompletely();
+    }
+  }
+
+  private static class UndeclaredEntitiesXMLResolver implements XMLResolver {
+
+    @Override
+    public Object resolveEntity(String arg0, String arg1, String fileName, String undeclaredEntity) throws XMLStreamException {
+      String undeclared = undeclaredEntity;
+      // avoid problems with XML docs containing undeclared entities.. return the entity under its raw form if not a Unicode expression
+      if (StringUtils.startsWithIgnoreCase(undeclaredEntity, "u") && undeclaredEntity.length() == 5) {
+        int unicodeCharHexValue = Integer.parseInt(undeclaredEntity.substring(1), 16);
+        if (Character.isDefined(unicodeCharHexValue)) {
+          undeclared = new String(new char[] {(char) unicodeCharHexValue});
+        }
+      }
+      return undeclared;
+    }
+  }
+
+  /**
+   * Simple interface for handling XML stream to parse.
+   */
+  @FunctionalInterface
+  public interface XmlStreamHandler {
+    void stream(SMHierarchicCursor rootCursor) throws XMLStreamException;
+  }
+
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/parser/package-info.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/parser/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+@ParametersAreNonnullByDefault
+package com.iadams.sonarqube.puppet.parser;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensor.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensor.java
@@ -1,0 +1,201 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.stream.XMLStreamException;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputComponent;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.measure.Metric;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.config.Configuration;
+import org.sonar.api.measures.CoreMetrics;
+import com.iadams.sonarqube.puppet.PuppetReportSensor;
+import com.iadams.sonarqube.puppet.parser.StaxParser;
+
+public class PuppetXUnitSensor extends PuppetReportSensor {
+  private static final Logger LOG = LoggerFactory.getLogger(PuppetXUnitSensor.class);
+
+  public static final String REPORT_PATH_KEY = "sonar.puppet.xunit.reportPath";
+  public static final String DEFAULT_REPORT_PATH = "xunit-reports/xunit-result-*.xml";
+  public static final String SKIP_DETAILS = "sonar.puppet.xunit.skipDetails";
+
+  private final FileSystem fileSystem;
+
+  public PuppetXUnitSensor(Configuration conf, FileSystem fileSystem) {
+    super(conf);
+    this.fileSystem = fileSystem;
+  }
+
+  @Override
+  protected String reportPathKey() {
+    return REPORT_PATH_KEY;
+  }
+
+  @Override
+  protected String defaultReportPath() {
+    return DEFAULT_REPORT_PATH;
+  }
+
+  @Override
+  protected void processReports(final SensorContext context, List<File> reports) throws XMLStreamException {
+    if (conf.getBoolean(SKIP_DETAILS).orElse(Boolean.FALSE)) {
+      simpleMode(context, reports);
+    } else {
+      detailedMode(context, reports);
+    }
+  }
+
+  private static void simpleMode(final SensorContext context, List<File> reports) throws XMLStreamException {
+    TestSuiteParser parserHandler = new TestSuiteParser();
+    StaxParser parser = new StaxParser(parserHandler);
+    for (File report : reports) {
+      parser.parse(report);
+    }
+
+    int testsCount = 0;
+    int testsSkipped = 0;
+    int testsErrors = 0;
+    int testsFailures = 0;
+    long testsTime = 0;
+    for (TestSuite report : parserHandler.getParsedReports()) {
+      testsCount += report.getTests() - report.getSkipped();
+      testsSkipped += report.getSkipped();
+      testsErrors += report.getErrors();
+      testsFailures += report.getFailures();
+      testsTime += report.getTime();
+    }
+
+    if (testsCount > 0) {
+      InputComponent module = context.module();
+      saveMeasure(context, module, CoreMetrics.TESTS, testsCount);
+      saveMeasure(context, module, CoreMetrics.SKIPPED_TESTS, testsSkipped);
+      saveMeasure(context, module, CoreMetrics.TEST_ERRORS, testsErrors);
+      saveMeasure(context, module, CoreMetrics.TEST_FAILURES, testsFailures);
+      saveMeasure(context, module, CoreMetrics.TEST_EXECUTION_TIME, testsTime);
+    }
+  }
+
+  private void detailedMode(final SensorContext context, List<File> reports) throws XMLStreamException {
+    for (File report : reports) {
+      TestSuiteParser parserHandler = new TestSuiteParser();
+      StaxParser parser = new StaxParser(parserHandler);
+      parser.parse(report);
+
+      LOG.info("Processing report '{}'", report);
+
+      processReportDetailed(context, parserHandler.getParsedReports());
+    }
+  }
+
+  private void processReportDetailed(SensorContext context, Collection<TestSuite> parsedReports) {
+    Collection<TestSuite> locatedResources = lookupResources(parsedReports);
+    for (TestSuite fileReport : locatedResources) {
+      InputFile inputFile = fileReport.getInputFile();
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Saving test execution measures for '{}' under resource '{}'", fileReport.getKey(), inputFile.relativePath());
+      }
+
+      saveMeasure(context, inputFile, CoreMetrics.SKIPPED_TESTS, fileReport.getSkipped());
+      saveMeasure(context, inputFile, CoreMetrics.TESTS, fileReport.getTests() - fileReport.getSkipped());
+      saveMeasure(context, inputFile, CoreMetrics.TEST_ERRORS, fileReport.getErrors());
+      saveMeasure(context, inputFile, CoreMetrics.TEST_FAILURES, fileReport.getFailures());
+      saveMeasure(context, inputFile, CoreMetrics.TEST_EXECUTION_TIME, fileReport.getTime());
+    }
+  }
+
+  private InputFile findResource(String fileKey) {
+    return findResourceUsingNoseTestsStrategy(fileKey);
+  }
+
+  private InputFile findResourceUsingNoseTestsStrategy(String fileKey) {
+    // a) check assuming the key doesnt contain the class name
+    String candidateKey = StringUtils.replace(fileKey, ".", "/") + ".py";
+
+    InputFile unitTestFile = getSonarTestFile(new File(candidateKey));
+
+    if (unitTestFile == null) {
+      // b) check assuming the key *does* contain the class name
+      String candidateKey2 = StringUtils.replace(StringUtils.substringBeforeLast(fileKey, "."), ".", "/") + ".py";
+      if ( !(candidateKey2.equals(candidateKey))) {
+        unitTestFile = getSonarTestFile(new File(candidateKey2));
+      }
+    }
+
+    return unitTestFile;
+  }
+
+  private Collection<TestSuite> lookupResources(Collection<TestSuite> testReports) {
+    Map<String, TestSuite> locatedReports = new HashMap<>();
+
+    for (TestSuite report : testReports) {
+      String fileKey = report.getKey();
+
+      LOG.debug("Trying to find a SonarQube resource for '{}'", fileKey);
+      InputFile inputFile = findResource(fileKey);
+      if (inputFile != null) {
+        LOG.debug("The resource was found '{}'", inputFile);
+
+        TestSuite summaryReport = locatedReports.get(inputFile.absolutePath());
+        if (summaryReport != null) {
+          summaryReport.addMeasures(report);
+        } else {
+          report.setInputFile(inputFile);
+          locatedReports.put(inputFile.absolutePath(), report);
+        }
+      } else {
+        LOG.warn("The resource for '{}' is not found, drilling down to the details of this test won't be possible", fileKey);
+      }
+    }
+
+    return locatedReports.values();
+  }
+
+  private InputFile getSonarTestFile(File file) {
+    LOG.debug("Using the key '{}' to lookup the resource in SonarQube", file.getPath());
+    return fileSystem.inputFile(fileSystem.predicates().is(file));
+  }
+
+  private static void saveMeasure(SensorContext context, InputComponent component, Metric<Integer> metric, int value) {
+    context.<Integer>newMeasure()
+      .on(component)
+      .forMetric(metric)
+      .withValue(value)
+      .save();
+  }
+
+  private static void saveMeasure(SensorContext context, InputComponent component, Metric<Long> metric, long value) {
+    context.<Long>newMeasure()
+      .on(component)
+      .forMetric(metric)
+      .withValue(value)
+      .save();
+  }
+
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestCase.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestCase.java
@@ -1,0 +1,104 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import org.apache.commons.lang.StringEscapeUtils;
+
+/**
+ * Represents a unit test case. Has a couple of data items like name, status, time etc. associated. Reports testcase details in
+ * sonar-conform XML
+ */
+public class TestCase {
+
+  private static final String STATUS_OK = "ok";
+  private static final String STATUS_ERROR = "error";
+  private static final String STATUS_FAILURE = "failure";
+  private static final String STATUS_SKIPPED = "skipped";
+
+  private String name;
+  private String status = STATUS_OK;
+  private String stackTrace;
+  private String errorMessage;
+  private int time = 0;
+
+  /**
+   * Constructs a testcase instance out of following parameters
+   * 
+   * @param name
+   *          The name of this testcase
+   * @param time
+   *          The execution time in milliseconds
+   * @param status
+   *          The execution status of the testcase
+   * @param stack
+   *          The stack trace occurred while executing of this testcase; pass "" if the testcase passed/skipped.
+   * @param msg
+   *          The error message associated with this testcase of the execution was erroneous; pass "" if not.
+   */
+  public TestCase(String name, int time, String status, String stack, String msg) {
+    this.name = name;
+    this.time = time;
+    this.stackTrace = stack;
+    this.errorMessage = msg;
+    this.status = status;
+  }
+
+  /**
+   * Returns true if this testcase is an error, false otherwise
+   */
+  public boolean isError() {
+    return STATUS_ERROR.equals(status);
+  }
+
+  /**
+   * Returns true if this testcase is a failure, false otherwise
+   */
+  public boolean isFailure() {
+    return STATUS_FAILURE.equals(status);
+  }
+
+  /**
+   * Returns true if this testcase has been skipped, failure, false otherwise
+   */
+  public boolean isSkipped() {
+    return STATUS_SKIPPED.equals(status);
+  }
+
+  public int getTime() {
+    return time;
+  }
+
+  /**
+   * Returns execution details as sonar-conform XML
+   */
+  public String getDetails() {
+    StringBuilder details = new StringBuilder();
+    details.append("<testcase status=\"").append(status).append("\" time=\"").append(time).append("\" name=\"").append(name).append("\"");
+    if (isError() || isFailure()) {
+      details.append(">").append(isError() ? "<error message=\"" : "<failure message=\"").append(StringEscapeUtils.escapeXml(errorMessage))
+          .append("\">").append("<![CDATA[").append(StringEscapeUtils.escapeXml(stackTrace)).append("]]>")
+          .append(isError() ? "</error>" : "</failure>").append("</testcase>");
+    } else {
+      details.append("/>");
+    }
+
+    return details.toString();
+  }
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestSuite.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestSuite.java
@@ -1,0 +1,153 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import org.sonar.api.batch.fs.InputFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a unit test suite. Contains testcases, maintains some statistics. Reports testcase details in sonar-conform XML
+ */
+public class TestSuite {
+
+  private String key;
+  private InputFile inputFile = null;
+  private int errors = 0;
+  private int skipped = 0;
+  private int tests = 0;
+  private int time = 0;
+  private int failures = 0;
+  private List<TestCase> testCases;
+
+  /**
+   * Creates a testsuite instance uniquely identified by the given key
+   * 
+   * @param key
+   *          The key to construct a testsuite for
+   */
+  public TestSuite(String key) {
+    this.key = key;
+    this.testCases = new ArrayList<>();
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public int getErrors() {
+    return errors;
+  }
+
+  public int getSkipped() {
+    return skipped;
+  }
+
+  public int getTests() {
+    return tests;
+  }
+
+  public int getTime() {
+    return time;
+  }
+
+  public int getFailures() {
+    return failures;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TestSuite that = (TestSuite) o;
+    return key.equals(that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return key.hashCode();
+  }
+
+  /**
+   * Adds the given test case to this testsuite maintaining the internal statistics
+   * 
+   * @param tc
+   *          the test case to add
+   */
+  public void addTestCase(TestCase tc) {
+    if (tc.isSkipped()) {
+      skipped++;
+    } else if (tc.isFailure()) {
+      failures++;
+    } else if (tc.isError()) {
+      errors++;
+    }
+    tests++;
+    time += tc.getTime();
+    testCases.add(tc);
+  }
+
+  /**
+   * Adds the measures contained by the given test suite to this test suite
+   * 
+   * @param ts
+   *          the test suite to add the measures from
+   */
+  public TestSuite addMeasures(TestSuite ts) {
+    for (TestCase tc : ts.getTestCases()) {
+      addTestCase(tc);
+    }
+    return this;
+  }
+
+  /**
+   * Returns the testcases contained by this test suite
+   */
+  public List<TestCase> getTestCases() {
+    return testCases;
+  }
+
+  /**
+   * Returns execution details as sonar-conform XML
+   */
+  public String getDetails() {
+    StringBuilder details = new StringBuilder();
+    details.append("<tests-details>");
+    for (TestCase tc : testCases) {
+      details.append(tc.getDetails());
+    }
+    details.append("</tests-details>");
+    return details.toString();
+  }
+
+  public void setInputFile(InputFile inputFile) {
+    this.inputFile = inputFile;
+  }
+
+  public InputFile getInputFile() {
+    return inputFile;
+  }
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestSuiteParser.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/TestSuiteParser.java
@@ -1,0 +1,117 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import org.codehaus.staxmate.in.ElementFilter;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+import org.codehaus.staxmate.in.SMInputCursor;
+import org.sonar.api.utils.ParsingUtils;
+import com.iadams.sonarqube.puppet.parser.StaxParser.XmlStreamHandler;
+import javax.xml.stream.XMLStreamException;
+import java.text.ParseException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class TestSuiteParser implements XmlStreamHandler {
+
+  private Map<String, TestSuite> testSuites = new HashMap<>();
+
+  @Override
+  public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
+    SMInputCursor testSuiteCursor = rootCursor.constructDescendantCursor(new ElementFilter("testsuite"));
+    while (testSuiteCursor.getNext() != null) {
+      String testSuiteClassName = testSuiteCursor.getAttrValue("name");
+
+      SMInputCursor testCaseCursor = testSuiteCursor.childElementCursor("testcase");
+      while (testCaseCursor.getNext() != null) {
+        String testClassName = getClassname(testCaseCursor, testSuiteClassName);
+        TestSuite report = testSuites.get(testClassName);
+        if (report == null) {
+          report = new TestSuite(testClassName);
+          testSuites.put(testClassName, report);
+        }
+        report.addTestCase(parseTestCaseTag(testCaseCursor));
+      }
+    }
+  }
+
+  /**
+   * Returns successfully parsed reports as a collection of TestSuite objects.
+   */
+  public Collection<TestSuite> getParsedReports() {
+    return testSuites.values();
+  }
+
+  private static String getClassname(SMInputCursor testCaseCursor, String defaultClassname) throws XMLStreamException {
+    String testClassName = testCaseCursor.getAttrValue("classname");
+    return testClassName == null ? defaultClassname : testClassName;
+  }
+
+  private static TestCase parseTestCaseTag(SMInputCursor testCaseCursor) throws XMLStreamException {
+    // TODO: get a decent grammar for the junit format and check the
+    // logic inside this method against it.
+
+    String name = parseTestCaseName(testCaseCursor);
+    Double time = parseTime(testCaseCursor);
+    String status = "ok";
+    String stack = "";
+    String msg = "";
+
+    SMInputCursor childCursor = testCaseCursor.childElementCursor();
+    if (childCursor.getNext() != null) {
+      String elementName = childCursor.getLocalName();
+      if ("skipped".equals(elementName)) {
+        status = "skipped";
+      } else if ("failure".equals(elementName)) {
+        status = "failure";
+        msg = childCursor.getAttrValue("message");
+        stack = childCursor.collectDescendantText();
+      } else if ("error".equals(elementName)) {
+        status = "error";
+        msg = childCursor.getAttrValue("message");
+        stack = childCursor.collectDescendantText();
+      }
+    }
+    return new TestCase(name, time.intValue(), status, stack, msg);
+  }
+
+  private static double parseTime(SMInputCursor testCaseCursor) throws XMLStreamException {
+    double time;
+    try {
+      Double tmp = ParsingUtils.parseNumber(testCaseCursor.getAttrValue("time"), Locale.ENGLISH);
+      time = ParsingUtils.scaleValue(tmp * 1000, 3);
+    } catch (ParseException e) {
+      throw new XMLStreamException(e);
+    }
+    return time;
+  }
+
+  private static String parseTestCaseName(SMInputCursor testCaseCursor) throws XMLStreamException {
+    String name = testCaseCursor.getAttrValue("name");
+    String classname = testCaseCursor.getAttrValue("CLASSNAME");
+    if (classname != null) {
+      name = classname + "/" + name;
+    }
+    return name;
+  }
+
+}

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/package-info.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+@ParametersAreNonnullByDefault
+package com.iadams.sonarqube.puppet.xunit;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/DirectoryScanner.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/DirectoryScanner.groovy
@@ -1,0 +1,60 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.sonar.api.utils.WildcardPattern;
+
+public class DirectoryScanner {
+
+  private final File baseDir;
+  private final WildcardPattern pattern;
+
+  public DirectoryScanner(File baseDir, WildcardPattern pattern) {
+    this.baseDir = baseDir;
+    this.pattern = pattern;
+  }
+
+  public List<File> getIncludedFiles() {
+    final String baseDirAbsolutePath = baseDir.getAbsolutePath();
+    IOFileFilter fileFilter = new IOFileFilter() {
+
+      @Override
+      public boolean accept(File dir, String name) {
+        return accept(new File(dir, name));
+      }
+
+      @Override
+      public boolean accept(File file) {
+        String path = file.getAbsolutePath();
+        path = path.substring(Math.min(baseDirAbsolutePath.length(), path.length()));
+        return pattern.match(FilenameUtils.separatorsToUnix(path));
+      }
+    };
+    return new ArrayList<>(FileUtils.listFiles(baseDir, fileFilter, TrueFileFilter.INSTANCE));
+  }
+
+}

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/parser/StaxParserTest.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/parser/StaxParserTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.parser;
+
+import javax.xml.stream.XMLStreamException;
+import org.codehaus.staxmate.in.SMHierarchicCursor;
+import org.junit.Test;
+import com.iadams.sonarqube.puppet.StaxParser.XmlStreamHandler;
+
+public class StaxParserTest {
+
+  @Test
+  public void test_XML_with_DTD() throws XMLStreamException {
+    StaxParser parser = new StaxParser(getTestHandler());
+    parser.parse(getClass().getClassLoader().getResourceAsStream("org/sonar/plugins/python/parser/dtd-test.xml"));
+  }
+
+  @Test
+  public void test_XML_with_XSD() throws XMLStreamException {
+    StaxParser parser = new StaxParser(getTestHandler());
+    parser.parse(getClass().getClassLoader().getResourceAsStream("org/sonar/plugins/python/parser/xsd-test.xml"));
+  }
+
+  @Test
+  public void test_XML_with_XSD_and_ampersand() throws XMLStreamException {
+    StaxParser parser = new StaxParser(getTestHandler());
+    parser.parse(getClass().getClassLoader().getResourceAsStream("org/sonar/plugins/python/parser/xsd-test-with-entity.xml"));
+  }
+
+  private XmlStreamHandler getTestHandler() {
+    return new XmlStreamHandler() {
+      public void stream(SMHierarchicCursor rootCursor) throws XMLStreamException {
+        rootCursor.advance();
+        while (rootCursor.getNext() != null) {
+        }
+      }
+    };
+  }
+
+}

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensorTest.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensorTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import java.io.File;
+import org.junit.Before;
+import org.junit.Test;
+import org.sonar.api.batch.fs.InputComponent;
+import org.sonar.api.batch.fs.internal.DefaultFileSystem;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
+import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
+import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.config.Settings;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PuppetXUnitSensorTest {
+
+  private File baseDir = new File("src/test/resources/com/iadams/sonarqube/puppet");
+  Settings settings;
+  PuppetXUnitSensor sensor;
+  SensorContextTester context = SensorContextTester.create(baseDir);
+  DefaultFileSystem fs;
+
+  @Before
+  public void setUp() {
+    settings = context.settings();
+    fs = new DefaultFileSystem(baseDir);
+    sensor = new PuppetXUnitSensor(context.config(), fs);
+  }
+
+  @Test
+  public void shouldSaveCorrectMeasures() {
+    DefaultInputFile testFile1 = TestInputFileBuilder.create("", "test_sample1.py").build();
+    DefaultInputFile testFile2 = TestInputFileBuilder.create("", "tests/dir/test_sample2.py").build();
+    fs.add(testFile1);
+    fs.add(testFile2);
+    sensor.execute(context);
+
+    assertThat(measure(testFile1, CoreMetrics.TESTS)).isEqualTo(3);
+    assertThat(measure(testFile2, CoreMetrics.TESTS)).isEqualTo(3);
+
+    assertThat(measure(testFile1, CoreMetrics.SKIPPED_TESTS)).isEqualTo(0);
+    assertThat(measure(testFile2, CoreMetrics.SKIPPED_TESTS)).isEqualTo(1);
+
+    assertThat(measure(testFile1, CoreMetrics.TEST_ERRORS)).isEqualTo(1);
+    assertThat(measure(testFile2, CoreMetrics.TEST_ERRORS)).isEqualTo(1);
+
+    assertThat(measure(testFile1, CoreMetrics.TEST_FAILURES)).isEqualTo(1);
+    assertThat(measure(testFile2, CoreMetrics.TEST_FAILURES)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldSaveCorrectMeasuresSimpleMode() {
+    settings.setProperty(PuppetXUnitSensor.SKIP_DETAILS, true);
+    fs.add(TestInputFileBuilder.create("", "test_sample.py").build());
+    fs.add(TestInputFileBuilder.create("", "tests/dir/test_sample.py").build());
+    sensor.execute(context);
+
+    // includes test with not found file
+    assertThat(moduleMeasure(CoreMetrics.TESTS)).isEqualTo(7);
+    assertThat(moduleMeasure(CoreMetrics.SKIPPED_TESTS)).isEqualTo(1);
+    assertThat(moduleMeasure(CoreMetrics.TEST_ERRORS)).isEqualTo(3);
+    assertThat(moduleMeasure(CoreMetrics.TEST_FAILURES)).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReportNothingWhenNoReportFound() {
+    DefaultInputFile testFile1 = TestInputFileBuilder.create("", "test_sample1.py").build();
+    fs.add(testFile1);
+
+    settings.setProperty(PuppetXUnitSensor.REPORT_PATH_KEY, "notexistingpath");
+    sensor = new PuppetXUnitSensor(context.config(), fs);
+    sensor.execute(context);
+
+    assertThat(context.measures(context.module().key())).isEmpty();
+    assertThat(context.measures(testFile1.key())).isEmpty();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowWhenGivenInvalidTime() {
+    settings.setProperty(PuppetXUnitSensor.REPORT_PATH_KEY, "xunit-reports/invalid-time-xunit-report.xml");
+    sensor = new PuppetXUnitSensor(context.config(), fs);
+    sensor.execute(context);
+  }
+
+  private Integer moduleMeasure(Metric<Integer> metric) {
+    return measure(context.module(), metric);
+  }
+
+  private Integer measure(InputComponent component, Metric<Integer> metric) {
+    return context.measure(component.key(), metric).value();
+  }
+
+}

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/TestCaseTest.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/TestCaseTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import org.junit.Test;
+
+public class TestCaseTest {
+  @Test
+  public void rendersRightDetails() {
+    Map<String, TestCase> ioMap = new HashMap<String, TestCase>();
+
+    ioMap.put("<testcase status=\"ok\" time=\"1\" name=\"name\"/>",
+              new TestCase("name", 1, "ok", "", ""));
+    ioMap.put("<testcase status=\"error\" time=\"1\" name=\"name\"><error message=\"errmsg\"><![CDATA[stack]]></error></testcase>",
+              new TestCase("name", 1, "error", "stack", "errmsg"));
+    ioMap.put("<testcase status=\"failure\" time=\"1\" name=\"name\"><failure message=\"errmsg\"><![CDATA[stack]]></failure></testcase>",
+              new TestCase("name", 1, "failure", "stack", "errmsg"));
+
+    for(Map.Entry<String, TestCase> entry: ioMap.entrySet()) {
+      assertEquals(entry.getKey(), entry.getValue().getDetails());
+    }
+  }
+}

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/TestSuiteTest.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/xunit/TestSuiteTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * SonarQube Puppet Plugin
+ * Copyright (C) 2011-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.iadams.sonarqube.puppet.xunit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSuiteTest {
+  TestSuite suite;
+  TestSuite equalSuite;
+  TestSuite otherSuite;
+
+  @Before
+  public void setUp() {
+    suite = new TestSuite("key");
+    equalSuite = new TestSuite("key");
+    otherSuite = new TestSuite("otherkey");
+  }
+
+  @Test
+  public void suiteDoesntEqualsNull() {
+    assert(!suite.equals(null));
+  }
+
+  @Test
+  public void suiteDoesntEqualsMiscObject() {
+    assert(!suite.equals("string"));
+  }
+
+  @Test
+  public void suiteEqualityIsReflexive() {
+    assert(suite.equals(suite));
+    assert(otherSuite.equals(otherSuite));
+    assert(equalSuite.equals(equalSuite));
+  }
+
+  @Test
+  public void suiteEqualityWorksAsExpected() {
+    assert(suite.equals(equalSuite));
+    assert(!suite.equals(otherSuite));
+  }
+
+  @Test
+  public void suiteHashWorksAsExpected() {
+    assert(suite.hashCode() == equalSuite.hashCode());
+    assert(suite.hashCode() != otherSuite.hashCode());
+  }
+
+  @Test
+  public void newBornSuiteShouldHaveVirginStatistics() {
+    assertEquals(suite.getTests(), 0);
+    assertEquals(suite.getErrors(), 0);
+    assertEquals(suite.getFailures(), 0);
+    assertEquals(suite.getSkipped(), 0);
+    assertEquals(suite.getTime(), 0);
+    assertEquals(suite.getDetails(), "<tests-details></tests-details>");
+  }
+
+  @Test
+  public void addingTestCaseShouldIncrementStatistics() {
+    int testBefore = suite.getTests();
+    int timeBefore = suite.getTime();
+
+    final int EXEC_TIME = 10;
+    suite.addTestCase(new TestCase("name", EXEC_TIME, "status", "stack", "msg"));
+
+    assertEquals(suite.getTests(), testBefore + 1);
+    assertEquals(suite.getTime(), timeBefore + EXEC_TIME);
+  }
+
+  @Test
+  public void addingAnErroneousTestCaseShouldIncrementErrorStatistic() {
+    int errorsBefore = suite.getErrors();
+    TestCase error = mock(TestCase.class);
+    when(error.isError()).thenReturn(true);
+
+    suite.addTestCase(error);
+
+    assertEquals(suite.getErrors(), errorsBefore + 1);
+  }
+
+  @Test
+  public void addingAFailedestCaseShouldIncrementFailedStatistic() {
+    int failedBefore = suite.getFailures();
+    TestCase failedTC = mock(TestCase.class);
+    when(failedTC.isFailure()).thenReturn(true);
+
+    suite.addTestCase(failedTC);
+
+    assertEquals(suite.getFailures(), failedBefore + 1);
+  }
+
+  @Test
+  public void addingASkippedTestCaseShouldIncrementSkippedStatistic() {
+    int skippedBefore = suite.getSkipped();
+    TestCase skippedTC = mock(TestCase.class);
+    when(skippedTC.isSkipped()).thenReturn(true);
+
+    suite.addTestCase(skippedTC);
+
+    assertEquals(suite.getSkipped(), skippedBefore + 1);
+  }
+
+  @Test
+  public void addingAnotherTestSuiteShouldMaintainStatistics() {
+    TestCase tc = mock(TestCase.class);
+    when(tc.isSkipped()).thenReturn(true);
+    TestSuite ts1 = new TestSuite("1");
+    TestSuite ts2 = new TestSuite("2");
+    ts1.addTestCase(tc);
+    ts2.addTestCase(tc);
+
+    TestSuite summedUp = ts1.addMeasures(ts2);
+
+    assertEquals(summedUp.getSkipped(), 2);
+  }
+}

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/dtd-test.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/dtd-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!DOCTYPE test SYSTEM "http://com.foo.bar/fake.dtd">
+<test>
+  <another-test/>
+</test>

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/xsd-test-with-entity.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/xsd-test-with-entity.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<test xmlns="http://www.test.org"
+      xmlns:xsi="http://www.w3.org/1999/XMLSchema/instance"
+      xsi:schemaLocation="http://www.test.org http://foo.bar.org/test.xsd">
+  <another-test>&#160;</another-test>
+  <another-test>&nbsp;</another-test>
+  <another-test>&xxx;</another-test>
+</test>

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/xsd-test.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/parser/xsd-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<test xmlns="http://www.test.org"
+      xmlns:xsi="http://www.w3.org/1999/XMLSchema/instance"
+      xsi:schemaLocation="http://www.test.org http://foo.bar.org/test.xsd">
+  <another-test/>
+</test>

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/invalid-time-xunit-report.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/invalid-time-xunit-report.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0">
+  <testcase classname="test_sample" name="test_successfull" time="brrrr" />
+</testsuite>

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/xunit-result-1.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/xunit-result-1.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="nosetests" tests="3" errors="1" failures="1" skip="0">
+  <testcase classname="test_sample1" name="test_successfull" time="0.000" />
+  <testcase classname="test_sample1" name="test_failed" time="0.000">
+    <failure type="exceptions.AssertionError" message=""><![CDATA[Traceback (most recent call last):
+    File "/usr/lib/python2.7/unittest/case.py", line 327, in run
+    testMethod()
+    File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
+    self.test(*self.arg)
+    File "/home/wen/src/test-projects/sonar-examples/projects/languages/python/python-sonar-runner/src/tests/test_sample.py", line 7, in test_failed
+    assert False
+    AssertionError
+    ]]></failure>
+  </testcase>
+  <testcase classname="test_sample1" name="test_error" time="0.000">
+    <error type="exceptions.NameError" message="global name 'not_exising_callable' is not defined"><![CDATA[Traceback (most recent call last):
+    File "/usr/lib/python2.7/unittest/case.py", line 327, in run
+    testMethod()
+    File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
+    self.test(*self.arg)
+    File "/home/wen/src/test-projects/sonar-examples/projects/languages/python/python-sonar-runner/src/tests/test_sample.py", line 10, in test_error
+    not_exising_callable()
+    NameError: global name 'not_exising_callable' is not defined
+    ]]></error>
+  </testcase>
+</testsuite>

--- a/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/xunit-result-2.xml
+++ b/sonar-puppet-plugin/src/test/resources/com/iadams/sonarqube/puppet/xunit-reports/xunit-result-2.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="nosetests" tests="5" errors="2" failures="1" skip="1">
+  <testcase classname="tests.dir.test_sample2.Test_Class" name="test_success" time="0.000">
+    <error type="exceptions.TypeError" message="test_success() takes no arguments (1 given)">
+      <![CDATA[Traceback (most recent call last):
+               File "c:\sdk\win32\1.1\Python26\lib\unittest.py", line 279, in run
+               testMethod()
+               File "c:\sdk\win32\1.1\python26\lib\site-packages\nose-1.1.2-py2.6.egg\nose\case.py", line 197, in runTest
+               self.test(*self.arg)
+               TypeError: test_success() takes no arguments (1 given)
+      ]]>
+    </error>
+  </testcase>
+  <testcase classname="tests.dir.test_sample2" name="test_skipped2" time="0.000">
+    <skipped type="nose.plugins.skip.SkipTest" message="">
+      <![CDATA[Traceback (most recent call last):
+               File "c:\sdk\win32\1.1\Python26\lib\unittest.py", line 279, in run
+               testMethod()
+               File "c:\sdk\win32\1.1\python26\lib\site-packages\nose-1.1.2-py2.6.egg\nose\case.py", line 197, in runTest
+               self.test(*self.arg)
+               File "E:\src\pysample\tests\dir\test_sample2.py", line 11, in test_skipped2
+               raise SkipTest
+               SkipTest
+      ]]>
+    </skipped>
+  </testcase>
+  <testcase classname="tests.dir.test_sample2" name="test_whichcovers" time="0.000" />
+  <testcase classname="tests.dir.test_sample2" name="test_failed" time="0.000">
+    <failure type="exceptions.AssertionError" message="">
+      <![CDATA[Traceback (most recent call last):
+               File "c:\sdk\win32\1.1\Python26\lib\unittest.py", line 279, in run
+               testMethod()
+               File "c:\sdk\win32\1.1\python26\lib\site-packages\nose-1.1.2-py2.6.egg\nose\case.py", line 197, in runTest
+               self.test(*self.arg)
+               File "E:\src\pysample\tests\dir\test_sample2.py", line 20, in test_failed
+               assert False
+               AssertionError
+      ]]>
+    </failure>
+  </testcase>
+  <testcase classname="tests.dir.no_such_file" name="test_error" time="0.000">
+    <error type="exceptions.NameError" message="global name 'not_exising_callable' is not defined">
+      <![CDATA[Traceback (most recent call last):
+               File "c:\sdk\win32\1.1\Python26\lib\unittest.py", line 279, in run
+               testMethod()
+               File "c:\sdk\win32\1.1\python26\lib\site-packages\nose-1.1.2-py2.6.egg\nose\case.py", line 197, in runTest
+               self.test(*self.arg)
+               File "E:\src\pysample\tests\dir\no_such_file.py", line 23, in test_error
+               not_exising_callable()
+               NameError: global name 'not_exising_callable' is not defined
+      ]]>
+    </error>
+  </testcase>
+</testsuite>


### PR DESCRIPTION
Just trying to make this plugin parse generic-test-date.  Just copied the relevant files from sonar-puppet, but since I'm a noob with java/groovy I'm stcuk ....
I guessed building is done executing ./gradlew build ... 
But always get error which I dont find a way to solve  them 

```
 /vagrant/playground/workflow/sonar-puppet/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensor.java:36: error: cannot find symbol
import org.sonar.api.config.Configuration;
                           ^
  symbol:   class Configuration
  location: package org.sonar.api.config
/vagrant/playground/workflow/sonar-puppet/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/PuppetReportSensor.java:31: error: cannot find symbol
import org.sonar.api.config.Configuration;
                           ^
  symbol:   class Configuration
  location: package org.sonar.api.config
/vagrant/playground/workflow/sonar-puppet/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/xunit/PuppetXUnitSensor.java:50: error: cannot find symbol
  public PuppetXUnitSensor(Configuration conf, FileSystem fileSystem) {
```
Maybe I'm just messing everything up ..... so any guidance is very welcome.
