### PR TITLE
Fix for Sonarqube 7.7

### DIFF
--- a/puppet-squid/src/test/groovy/com/iadams/sonarqube/puppet/PuppetAstScannerSpec.groovy
+++ b/puppet-squid/src/test/groovy/com/iadams/sonarqube/puppet/PuppetAstScannerSpec.groovy
@@ -36,15 +36,16 @@ import spock.lang.Specification
 
 class PuppetAstScannerSpec extends Specification {
 
-  def "files"() {
-    given:
-    AstScanner<Grammar> scanner = PuppetAstScanner.create(new PuppetConfiguration(Charsets.UTF_8))
-    scanner.scanFiles(ImmutableList.of(new File("src/test/resources/metrics/lines_of_code.pp"), new File("src/test/resources/metrics/comments.pp")))
-    SourceProject project = (SourceProject) scanner.getIndex().search(new QueryByType(SourceProject.class)).iterator().next()
-
-    expect:
-    project.getInt(PuppetMetric.FILES) == 2
-  }
+// Sonarqube 7.7: java.lang.UnsupportedOperationException: Metric 'files' should not be computed by a Sensor
+//  def "files"() {
+//    given:
+//    AstScanner<Grammar> scanner = PuppetAstScanner.create(new PuppetConfiguration(Charsets.UTF_8))
+//    scanner.scanFiles(ImmutableList.of(new File("src/test/resources/metrics/lines_of_code.pp"), new File("src/test/resources/metrics/comments.pp")))
+//    SourceProject project = (SourceProject) scanner.getIndex().search(new QueryByType(SourceProject.class)).iterator().next()
+//
+//    expect:
+//    project.getInt(PuppetMetric.FILES) == 2
+//  }
 
   def "comments"() {
     given:

--- a/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/PuppetSquidSensor.java
+++ b/sonar-puppet-plugin/src/main/java/com/iadams/sonarqube/puppet/PuppetSquidSensor.java
@@ -132,7 +132,8 @@ public final class PuppetSquidSensor implements Sensor {
   }
 
   private void saveMeasures(InputFile sonarFile, SourceFile squidFile) {
-    saveMetricOnFile(sonarFile, CoreMetrics.FILES, squidFile.getInt(PuppetMetric.FILES));
+    // Sonarqube 7.7: java.lang.UnsupportedOperationException: Metric 'files' should not be computed by a Sensor
+    // saveMetricOnFile(sonarFile, CoreMetrics.FILES, squidFile.getInt(PuppetMetric.FILES));
     saveMetricOnFile(sonarFile, CoreMetrics.LINES, squidFile.getInt(PuppetMetric.LINES));
     saveMetricOnFile(sonarFile, CoreMetrics.NCLOC, squidFile.getInt(PuppetMetric.LINES_OF_CODE));
     saveMetricOnFile(sonarFile, CoreMetrics.STATEMENTS, squidFile.getInt(PuppetMetric.STATEMENTS));

--- a/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/PuppetSquidSensorSpec.groovy
+++ b/sonar-puppet-plugin/src/test/groovy/com/iadams/sonarqube/puppet/PuppetSquidSensorSpec.groovy
@@ -89,7 +89,8 @@ class PuppetSquidSensorSpec extends Specification {
 
     expect:
     context.measure(key, CoreMetrics.NCLOC).value() == 14
-    context.measure(key, CoreMetrics.FILES).value() == 1
+    // Sonarqube 7.7: java.lang.UnsupportedOperationException: Metric 'files' should not be computed by a Sensor
+    // context.measure(key, CoreMetrics.FILES).value() == 1
     context.measure(key, CoreMetrics.STATEMENTS).value() == 7
     context.measure(key, CoreMetrics.CLASSES).value() == 2
     context.measure(key, CoreMetrics.COMPLEXITY).value() == 9


### PR DESCRIPTION
This pull request fixes an exception raised on Sonarqube 7.7:
`java.lang.UnsupportedOperationException: Metric 'files' should not be computed by a Sensor`